### PR TITLE
change dependency repos urls to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,11 @@
 <repositories>
       <repository>
         <id>clojars.org</id>
-        <url>http://clojars.org/repo</url>
+        <url>https://clojars.org/repo</url>
       </repository>
       <repository>
        <id>geotoolkit</id>
-       <url>http://maven.geotoolkit.org/</url>
+       <url>https://maven.geotoolkit.org/</url>
       </repository>
 </repositories>
 


### PR DESCRIPTION
maven won’t build anymore without this change