### PR TITLE
Update documentation to not need Java 6

### DIFF
--- a/README-orig.txt
+++ b/README-orig.txt
@@ -1,29 +1,29 @@
 // $Id$
 /**
  * Copyright 2010 Gerhard Aigner
- * 
+ *
  * This file is part of BRISS.
- * 
+ *
  * BRISS is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
  * Foundation, either version 3 of the License, or (at your option) any later
  * version.
- * 
+ *
  * BRISS is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * BRISS. If not, see http://www.gnu.org/licenses/.
  */
- 
+
 ################################################
-BRISS - BRight Snippet Sire 
+BRISS - BRight Snippet Sire
 ################################################
 
-This is a small application to crop PDF files. It helps the user to decide what 
+This is a small application to crop PDF files. It helps the user to decide what
 should be cropped by creating a overlay of similar pages (=>all pages within a pdf
- having the same size, orientation(even/odd)). 
+ having the same size, orientation(even/odd)).
 
 
 ########################
@@ -32,10 +32,10 @@ General
  * Homepage : http://sourceforge.net/projects/briss/
  * License: GPLv3
  * Author: Gerhard Aigner (gerhard.aigner@gmail.com
- * Requirements: Java 6
+ * Requirements: Java
  * Operating systems: Windows, Linux, MacOSX
- * This software uses two libraries to render and crop PDF files: 
-  * itext (AGPLv3) http://itextpdf.com/ 
+ * This software uses two libraries to render and crop PDF files:
+  * itext (AGPLv3) http://itextpdf.com/
   * jpedal (LGPL) http://www.jpedal.org/
 
 
@@ -48,7 +48,7 @@ java -jar briss-0.9.jar
 or
 java -jar briss-0.9.jar cropthis.pdf
 
-(The second line comes in handy if you want shortlinks for pdf editing) 
+(The second line comes in handy if you want shortlinks for pdf editing)
 
 
 ########################
@@ -62,7 +62,7 @@ java -jar briss-0.9.jar -s [SOURCEFILE] [-d [DESTINATIONFILE]]
 
 Example:
 java -jar briss-0.9.jar -s dogeatdog.pdf -d dogcrop.pdf
-java -jar briss-0.9.jar -s dogeatdog.pdf 
+java -jar briss-0.9.jar -s dogeatdog.pdf
 
 the second line will create the cropped pdf into dogeatdog_cropped.pdf
 
@@ -77,7 +77,7 @@ Instructions
  2.1) Press the left mouse button on a corner where you want to start
  2.2) Draw the rectangle
  2.3) Release the mouse button
- * [OPTIONAL] Drag around crop rectangles (press and hold mouse button down)   
+ * [OPTIONAL] Drag around crop rectangles (press and hold mouse button down)
  * [OPTIONAL] Set width/height to maximum: Select the crop rectangles by holding
     down CTRL + left click into rectangle to select. All crop rectangles will be
     resized to the biggest one, either on width or height.
@@ -91,6 +91,6 @@ Instructions
 ########################
 Problems
 ########################
-* If you want to crop really big files it might be necessary to start briss with 
-an additional parameter: "-Xms128m -Xmx1024m" (complete call would look like: 
+* If you want to crop really big files it might be necessary to start briss with
+an additional parameter: "-Xms128m -Xmx1024m" (complete call would look like:
 "java -Xms128m -Xmx1024m -jar briss-0.9.jar")

--- a/README.html
+++ b/README.html
@@ -167,7 +167,7 @@ the <a href="http://www.omnigia.com/news/content/briss-pdf-cropper-and-rearrange
 <h2 id="sec-2"><span class="section-number-2">2</span> DEPENDENCIES</h2>
 <div class="outline-text-2" id="text-2">
 <ul class="org-ul">
-<li>Java 6
+<li>Java
 </li>
 <li>maven
 </li>

--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
 
 * DEPENDENCIES
 
-  * Java 6
+  * Java
   * maven
   * itext, jpedal and Java Advanced Imaging API (pulled by maven during build)
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,11 @@
 <repositories>
       <repository>
         <id>clojars.org</id>
-        <url>http://clojars.org/repo</url>
+        <url>https://clojars.org/repo</url>
       </repository>
       <repository>
        <id>geotoolkit</id>
-       <url>http://maven.geotoolkit.org/</url>
+       <url>https://maven.geotoolkit.org/</url>
       </repository>
 </repositories>
 


### PR DESCRIPTION
Thankfully it isn't needed. I didn't specify which java was needed to avoid such a difference between documentation and code happening in the future.

Also includes the code from the https pull still open